### PR TITLE
Always run reports action on amd64

### DIFF
--- a/action-surefire-report/Dockerfile
+++ b/action-surefire-report/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-bookworm-slim
+FROM --platform=linux/amd64 node:20-bookworm-slim
 
 COPY dist /dist
 


### PR DESCRIPTION
This should allow using this action in jobs using the new ARM runners. An alternative is to create a copy of this action built for ARM, but since it only runs on failed jobs, I figured the overhead of emulation is acceptable. As a reminder - we use this version with native libxml to greatly reduce the memory usage with large reports.

I'll test it here: https://github.com/trinodb/trino/pull/24730